### PR TITLE
Replace commented-out code sections with crude feature flags

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@
 [flake8]
 ignore = E501,E127,E128,E265,E301,E302,E266
 max-line-length = 100
-exclude = .ropeproject,api_tests/*,tests/*,scripts/*,src,website/uploads/,website/static/**/*,website/settings/*,framework/forms/*,website/addons/*/tests/*,env,venv,node_modules,admin/static/*
+exclude = .ropeproject,api_tests/*,tests/*,scripts/*,src,website/uploads/,website/static/**/*,website/settings/*,website-ember/*,framework/forms/*,website/addons/*/tests/*,env,venv,node_modules,admin/static/*

--- a/website-ember/app/components/contributor-manager/component.js
+++ b/website-ember/app/components/contributor-manager/component.js
@@ -69,8 +69,8 @@ export default Ember.Component.extend({
     updateAttributes: function(contributors) {
         var proposedChanges = this.checkProposedChanges(contributors);
         this.set('changed', proposedChanges.changed);
-        proposedChanges.numAdmins > 0 ? this.set('hasMinAdmins', true) : this.set('hasMinAdmins', false);
-        proposedChanges.numBibliographic > 0 ? this.set('hasMinBibliographic', true) : this.set('hasMinBibliographic', false);
+        this.set('hasMinAdmins', (proposedChanges.numAdmins > 0));
+        this.set('hasMinBibliographic', (proposedChanges.numBibliographic > 0));
     },
     checkProposedChanges: function(contributors) {
         var _this = this;

--- a/website-ember/app/components/modal-add-contribs.js
+++ b/website-ember/app/components/modal-add-contribs.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+import config from '../config/environment';
+
 import deferredPromise from '../utils/deferred-promise';
 import permissions, { permissionSelector } from 'ember-osf/const/permissions';
 
@@ -27,6 +29,13 @@ let UserContributor = Ember.ObjectProxy.extend({
  */
 export default Ember.Component.extend({
     store: Ember.inject.service('store'),
+
+    // FIXME: Feature flags consumed by template- remove dependence when tickets are resolved!
+    showUnregisteredContributorsUI: config.APP.featureFlags.unregisteredContributors,
+    showEducationSchoolsUI: config.APP.featureFlags.educationSchools,
+    showProjectsInCommon: config.APP.featureFlags.collaborationCount,
+    showPaginationWidget: config.APP.featureFlags.paginationWidget,
+    showTreeWidget: config.APP.featureFlags.treeWidgetAvailable,
 
     /**
      * @property {String} page Which page of the modal to display

--- a/website-ember/app/controllers/node-contributors.js
+++ b/website-ember/app/controllers/node-contributors.js
@@ -39,7 +39,7 @@ export default Ember.Controller.extend(NodeActionsMixin, {
             this._super(...arguments);
             this.get('contributors').removeObject(contrib);
         },
-        updateContributors(contributors, permissionsChanges, bibliographicChanges) {
+        updateContributors(contributors, permissionsChanges, bibliographicChanges) { // jshint ignore:line
             this._super(...arguments);
             // TODO how to send multiple save actions in a row without reload?
             // May be related to how loading contributors initially.

--- a/website-ember/app/styles/app.scss
+++ b/website-ember/app/styles/app.scss
@@ -12,3 +12,9 @@ body {
     -webkit-font-smoothing: antialiased;
     font-family: 'Open Sans', 'Helvetica Neue', sans-serif;
 }
+
+.feature-flag {
+    // Visibly style UI that depends on feature flags
+    background-color: #DDDDDD;
+    font-style: italic;
+}

--- a/website-ember/app/templates/components/modal-add-contribs.hbs
+++ b/website-ember/app/templates/components/modal-add-contribs.hbs
@@ -47,7 +47,7 @@
                     {{!-- Note: Removed "notifications" block because it seemed to be no longer used in staticjs code. TODO: Verify this is correct --}}
 
                     {{!-- Intent: Only show search results if done loading and results were found --}}
-                    {{#if (and usersFound (not isLoading))}}
+                    {{#if (and (not-eq usersFound null) (not isLoading))}}
                         {{#if usersFound.length}}
                             <table class="table-condensed">
                                 <tbody>

--- a/website-ember/app/templates/components/modal-add-contribs.hbs
+++ b/website-ember/app/templates/components/modal-add-contribs.hbs
@@ -79,47 +79,56 @@
                                                 </a>
                                                 <br>
 
-                                                {{!-- TODO: Identify datasource for these fields in API response and add to model as appropriate --}}
-                                                {{!--
-                                                <span data-bind="if: contributor.employment">
-                                                    <span class='small'
-                                                        data-bind="text: contributor.employment">
-                                                    </span><br>
-                                                </span>
-                                                <span data-bind="if: contributor.education">
-                                                    <span
-                                                        class='small'
-                                                        data-bind="text: contributor.education">
-                                                    </span><br>
-                                                </span>
-
-                                                <span class='small'
-                                                      data-bind="text: contributor.displayProjectsInCommon">
-                                                </span>
-                                                <span class='text-muted' data-bind="visible: !contributor.registered">(unregistered)</span>
-                                                --}}
+                                                {{#if showEducationSchoolsUI}}
+                                                    {{!-- TODO: Identify datasource for these fields in API response and add to model as appropriate . Remove lingering knockout. --}}
+                                                    <span class="feature-flag">
+                                                        <span data-bind="if: contributor.employment">
+                                                            <span class='small'>Day Job {{person.employment}}</span><br>
+                                                        </span>
+                                                        <span data-bind="if: contributor.education">
+                                                            <span class='small'>Virginia Tech {{person.education}}</span><br>
+                                                        </span>
+                                                    </span>
+                                                {{/if}}
+                                                {{#if showProjectsInCommon}}
+                                                    <span class="feature-flag">
+                                                        <span class='small'>
+                                                            Probably a collaborator? {{person.projectsInCommon}}
+                                                        </span>
+                                                    </span>
+                                                {{/if}}
+                                                {{#if showUnregisteredContributorsUI}}
+                                                    <span class="feature-flag">
+                                                        {{#if person.unregisteredContributor}}(unregistered){{/if}}
+                                                    </span>
+                                                {{/if}}
                                             </td>
                                         </tr>
                                     {{/each}}
                                 </tbody>
                             </table>
 
-                            {{!-- TODO: Support paginated result fetching widget. Moved from help-block style to here? --}}
-                            {{!-- <ul class="pagination pagination-sm" data-bind="foreach: paginators">
-                                <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>
-                            </ul> --}}
+                            {{#if showPaginationWidget}}
+                                {{!-- TODO: Support paginated result fetching widget. Moved from help-block style to here? --}}
+                                <ul class="pagination pagination-sm feature-flag" data-bind="foreach: paginators">
+                                    <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>
+                                </ul>
+                            {{/if}}
 
-                            {{!-- TODO: Restore this when unregistered contributors are implemented in the API
-                            <p>
-                                <button {{action 'selectPage' 'invite'}} class="btn-link">Add <strong><em>{{_searchText}}</em></strong> as an unregistered contributor</button>.
-                            </p>
-                            --}}
+                            {{#if showUnregisteredContributorsUI}}
+                                {{!-- TODO: Restore this when unregistered contributors are implemented in the API --}}
+                                <p class="feature-flag">
+                                    <a {{action 'selectPage' 'invite'}}>Add <strong><em>{{_searchText}}</em></strong> as an unregistered contributor</a>.
+                                </p>
+                            {{/if}}
                         {{else}}
                             No results found.
-                        {{!-- TODO: Restore text below when unreg contribs implemented in the API
-                            Try a more specific search or
-                            <button {{action 'selectPage' 'invite'}} class="btn-link">add <strong><em>{{_searchText}}</em></strong> as an unregistered contributor</button>.
-                            --}}
+                            {{#if showUnregisteredContributorsUI}}
+                                <span class="feature-flag">
+                                    Try a more specific search or
+                                    <a {{action 'selectPage' 'invite'}} class="btn-link">add <strong><em>{{_searchText}}</em></strong> as an unregistered contributor</a>.
+                                </span>
+                            {{/if}}
                         {{/if}}
                     {{/if}}
 
@@ -257,12 +266,12 @@
         <button class="btn btn-default" {{action 'close' target=footer}}>Cancel</button>
 
         {{#if (and contribsToAdd (eq page 'whom'))}}
-            {{!-- {{#if node.children}}
-                TODO: suppress "select child components" page until treebeard equivalent available. Also, children check should not require server call
+            {{#if (and node.children showTreeWidget) }}
+                {{!-- TODO: suppress "select child components" page until treebeard equivalent available. Also, children check should not require server call --}}
                 <button class="btn btn-primary" {{action 'selectPage' 'which'}}>Next</button>
-            {{else}}  --}}
-            <button class="btn btn-success" {{action 'submitContributors'}}>Add</button>
-            {{!-- {{/if}} --}}
+            {{else}}
+                <button class="btn btn-success" {{action 'submitContributors'}}>Add</button>
+            {{/if}}
         {{/if}}
 
         {{#if (eq page 'which')}}

--- a/website-ember/config/environment.js
+++ b/website-ember/config/environment.js
@@ -32,9 +32,9 @@ module.exports = function(environment) {
                 unregisteredContributors: true, // Blocked by OSF-6761. Must work with cookies.
                 educationSchools: true, // Blocked by OSF-6769, serializer must provide data
                 collaborationCount: true, // # projects in common to display in search results: No specific ticket or commitment to implement
-                paginationWidget: false, // Widget to paginate multiple existing or new results; no ticket available
-                viewOnlyLinks: false,
-                treeWidgetAvailable: true, // Depends on hierarchical treebeard-like widget; no ticket available
+                paginationWidget: false, // Blocked by EOSF-135, Widget to paginate multiple existing or new results
+                viewOnlyLinks: false, // Blocked by EOSF-112
+                treeWidgetAvailable: true, // Blocked by EOSF-134. Depends on hierarchical treebeard-like widget; no ticket available
             }
         }
     };

--- a/website-ember/config/environment.js
+++ b/website-ember/config/environment.js
@@ -27,6 +27,15 @@ module.exports = function(environment) {
         APP: {
             // Here you can pass flags/options to your application instance
             // when it is created
+            featureFlags: {
+                // Feature flags: things not ready to release, or parts of UI that depend on unreleased APIv2 functionality
+                unregisteredContributors: true, // Blocked by OSF-6761. Must work with cookies.
+                educationSchools: true, // Blocked by OSF-6769, serializer must provide data
+                collaborationCount: true, // # projects in common to display in search results: No specific ticket or commitment to implement
+                paginationWidget: false, // Widget to paginate multiple existing or new results; no ticket available
+                viewOnlyLinks: false,
+                treeWidgetAvailable: true, // Depends on hierarchical treebeard-like widget; no ticket available
+            }
         }
     };
 


### PR DESCRIPTION
## Purpose

Some tidying of template. Attempts to track things needed for the page by introducing a set of crude feature flags, rather than commenting things out.
## Summary of changes

Hides code behind conditionals instead of comments.

Also adds a `feature-flag` css class to mark UI in progress.

<img width="323" alt="screen shot 2016-07-28 at 5 44 27 pm" src="https://cloud.githubusercontent.com/assets/2957073/17230584/f4b6e376-54ea-11e6-92b4-59a28b01cfbc.png">
## Ticket

https://openscience.atlassian.net/browse/EOSF-117
