### PR TITLE
[NPD] Change email template

### DIFF
--- a/website/templates/emails/new_pending_submissions.html.mako
+++ b/website/templates/emails/new_pending_submissions.html.mako
@@ -7,7 +7,7 @@
                 % if is_request_email:
                     <span class="person" style="font-weight: bold;">${requester.fullname}</span>
                 % else:
-                    <span class="person" style="font-weight: bold;">${', '.join(reviewable.node.contributors.values_list('fullname', flat=True))}</span>
+                    <span class="person" style="font-weight: bold;">${', '.join(reviewable.contributors.values_list('fullname', flat=True))}</span>
                 % endif
                 ${message}
             </span>


### PR DESCRIPTION
## Purpose

Because `reviewables` doesn't have `node` now, we don't need to get contributors from node anymore.